### PR TITLE
feat(frontend): implement true dark mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Scrum Poker</title>
   </head>
-  <body>
+  <body class="bg-black text-white">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <AuthProvider>
       <RoomProvider>
-        <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-gray-900">
+        <div className="min-h-screen bg-black text-white">
           <BrowserRouter>
             <Routes>
               <Route path="/" element={<Home />} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,10 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply bg-black text-white;
+  }
+}
+
 @layer components {
   .btn {
-    @apply bg-gradient-to-r from-slate-700 to-slate-800 hover:from-slate-600 hover:to-slate-700 
-           text-white font-medium px-6 py-3 rounded-lg shadow-md 
+    @apply bg-gradient-to-r from-slate-700 to-slate-800 hover:from-slate-600 hover:to-slate-700
+           text-white font-medium px-6 py-3 rounded-lg shadow-md
            transition-all duration-300 hover:shadow-lg
            disabled:opacity-50 disabled:cursor-not-allowed
            focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-transparent;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -60,9 +60,7 @@ export default function Home() {
               <div className="w-full border-t border-white/10"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-4 bg-gradient-to-br from-slate-900 via-slate-800 to-gray-900 text-white/50">
-                or
-              </span>
+              <span className="px-4 bg-black text-white/50">or</span>
             </div>
           </div>
 

--- a/frontend/src/pages/Room.tsx
+++ b/frontend/src/pages/Room.tsx
@@ -49,7 +49,7 @@ export default function Room() {
             <button
               type="button"
               onClick={() => navigate("/")}
-              className="px-6 py-3 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors ml-4"
+              className="px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-700 transition-colors ml-4"
             >
               Back to Home
             </button>
@@ -65,7 +65,7 @@ export default function Room() {
       <PageLayout>
         <div className="flex flex-col items-center justify-center min-h-[400px]">
           <LoadingSpinner />
-          <p className="mt-4 text-gray-600">Joining room...</p>
+          <p className="mt-4 text-gray-400">Joining room...</p>
         </div>
       </PageLayout>
     );


### PR DESCRIPTION
## Summary
- set global dark background and text colors
- remove gradient backgrounds for true dark appearance
- adjust UI elements for high contrast

## Testing
- `pnpm test` *(fails: Cannot find dependency 'jsdom', server tests missing)*
- `pnpm --filter frontend test`
- `pnpm --filter server test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bdd875e0d08329ac44d43e5d4405bc