### PR TITLE
feat: allow custom room naming

### DIFF
--- a/frontend/src/components/RoomHeader.tsx
+++ b/frontend/src/components/RoomHeader.tsx
@@ -1,10 +1,9 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useRoom } from "../hooks/useRoom";
 import Card from "./Card";
 import Button from "./ds/Button/Button";
 
 export default function RoomHeader() {
-  const { roomId } = useParams();
   const navigate = useNavigate();
   const { roomState, votedCount, leaveRoom } = useRoom();
 
@@ -20,7 +19,7 @@ export default function RoomHeader() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-medium text-white mb-2">
-              Room {roomId}
+              Room {roomState.id}
             </h1>
             <p className="text-gray-400">
               {votedCount} of {roomState.participants.length} participants voted

--- a/server/roomManager.ts
+++ b/server/roomManager.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import logger from "./logger";
 
 export const FIB_DECK: Array<number | "?"> = [
@@ -25,7 +24,7 @@ type Participant = {
 type Room = {
   id: string;
   ownerId: string;
-  name?: string;
+  name: string;
   participants: Map<string, Participant>;
   status: "voting";
 };
@@ -62,29 +61,59 @@ export type PokerNamespace = {
 export class RoomManager {
   constructor() {
     this.rooms = new Map<string, Room>();
+    this.archivedRooms = new Set<string>();
     logger.info("RoomManager was initialized");
   }
 
   private rooms: Map<string, Room>;
+  private archivedRooms: Set<string>;
 
-  createRoom(ownerId: string, name?: string): Room {
-    const id = randomUUID();
+  private normalizeRoomId(roomId: string): string {
+    return roomId.trim().toLowerCase();
+  }
+
+  private validateRoomId(roomId: string): string {
+    const normalized = this.normalizeRoomId(roomId);
+    if (!normalized) {
+      throw new Error("Room name is required");
+    }
+    if (normalized.length > 50) {
+      throw new Error("Room name must be at most 50 characters");
+    }
+    if (!/^[a-z_-]+$/.test(normalized)) {
+      throw new Error(
+        "Room name can only contain lowercase letters, hyphens, and underscores",
+      );
+    }
+    return normalized;
+  }
+
+  createRoom(ownerId: string, ownerName: string, roomId: string): Room {
+    const id = this.validateRoomId(roomId);
+
+    if (this.rooms.has(id)) {
+      logger.warn({ roomId: id, ownerId }, "Room creation was rejected");
+      throw new Error("Room already exists");
+    }
+
     const room: Room = {
       id,
       ownerId,
-      name,
+      name: id,
       participants: new Map<string, Participant>(),
       status: "voting",
     };
     this.rooms.set(id, room);
+    this.archivedRooms.add(id);
+
     room.participants.set(ownerId, {
       id: ownerId,
-      name: name || "Owner",
+      name: ownerName,
       hasVoted: false,
     });
 
     logger.info(
-      { roomId: id, ownerId, ownerName: name || "Owner" },
+      { roomId: id, ownerId, ownerName },
       "Room was created",
     );
 
@@ -92,12 +121,16 @@ export class RoomManager {
   }
 
   joinRoom(id: string, user: User): Room {
-    const room = this.rooms.get(id);
+    const roomId = this.validateRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) {
       logger.warn(
-        { roomId: id, userId: user.id, userName: user.name },
+        { roomId, userId: user.id, userName: user.name },
         "Room join was rejected",
       );
+      if (this.archivedRooms.has(roomId)) {
+        throw new Error("Room does not exist anymore, you want to reopen it?");
+      }
       throw new Error("Room not found");
     }
 
@@ -110,7 +143,7 @@ export class RoomManager {
 
     logger.info(
       {
-        roomId: id,
+        roomId,
         userId: user.id,
         userName: user.name,
         rejoined: wasAlreadyInRoom,
@@ -118,7 +151,7 @@ export class RoomManager {
       "User joined room",
     );
     logger.info(
-      { roomId: id, participants: room.participants.size },
+      { roomId, participants: room.participants.size },
       "Room participant count was updated",
     );
 
@@ -126,17 +159,18 @@ export class RoomManager {
   }
 
   castVote(id: string, userId: string, value: number | "?"): void {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) {
       logger.warn(
-        { roomId: id, userId, value },
+        { roomId, userId, value },
         "Vote was rejected, room not found",
       );
       return;
     }
     if (!FIB_DECK.includes(value)) {
       logger.warn(
-        { roomId: id, userId, value },
+        { roomId, userId, value },
         "Vote was rejected, invalid value",
       );
       return;
@@ -150,7 +184,7 @@ export class RoomManager {
 
       logger.info(
         {
-          roomId: id,
+          roomId,
           userId,
           userName: p.name,
           value,
@@ -164,21 +198,22 @@ export class RoomManager {
       ).length;
       logger.info(
         {
-          roomId: id,
+          roomId,
           votedCount,
           totalParticipants: room.participants.size,
         },
         "Vote progress was recorded",
       );
     } else {
-      logger.warn({ roomId: id, userId }, "Vote was rejected, user not found");
+      logger.warn({ roomId, userId }, "Vote was rejected, user not found");
     }
   }
 
   clearVotes(id: string): void {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) {
-      logger.warn({ roomId: id }, "Clear votes was rejected, room not found");
+      logger.warn({ roomId }, "Clear votes was rejected, room not found");
       return;
     }
 
@@ -190,15 +225,16 @@ export class RoomManager {
       delete p.value;
     }
 
-    logger.info({ roomId: id, removedVotes: votedCount }, "Votes were cleared");
+    logger.info({ roomId, removedVotes: votedCount }, "Votes were cleared");
   }
 
   isOwner(id: string, userId: string): boolean {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     const isOwner = !!room && room.ownerId === userId;
     if (room && !isOwner) {
       logger.warn(
-        { roomId: id, userId, ownerId: room.ownerId },
+        { roomId, userId, ownerId: room.ownerId },
         "Access was denied, user not owner",
       );
     }
@@ -206,17 +242,19 @@ export class RoomManager {
   }
 
   hasAnyVotes(id: string): boolean {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) return false;
     const hasVotes = Array.from(room.participants.values()).some(
       (p) => p.hasVoted,
     );
-    logger.info({ roomId: id, hasVotes }, "Room votes were checked");
+    logger.info({ roomId, hasVotes }, "Room votes were checked");
     return hasVotes;
   }
 
   getState(id: string): RoomState | null {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) return null;
     return {
       id: room.id,
@@ -231,7 +269,8 @@ export class RoomManager {
   }
 
   getProgress(id: string): VoteProgress | null {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) return null;
     const result: VoteProgress = {};
     for (const [id, p] of room.participants) result[id] = p.hasVoted;
@@ -239,9 +278,10 @@ export class RoomManager {
   }
 
   startReveal(id: string, namespace: PokerNamespace): void {
-    const room = this.rooms.get(id);
+    const roomId = this.normalizeRoomId(id);
+    const room = this.rooms.get(roomId);
     if (!room) {
-      logger.warn({ roomId: id }, "Reveal was rejected, room not found");
+      logger.warn({ roomId }, "Reveal was rejected, room not found");
       return;
     }
 
@@ -250,7 +290,7 @@ export class RoomManager {
       (p) => p.hasVoted,
     );
     if (!hasAnyVotes) {
-      logger.warn({ roomId: id }, "Reveal was blocked, no votes");
+      logger.warn({ roomId }, "Reveal was blocked, no votes");
       return; // Don't start reveal if no one has voted
     }
 
@@ -259,7 +299,7 @@ export class RoomManager {
     ).length;
     logger.info(
       {
-        roomId: id,
+        roomId,
         votedCount,
         totalParticipants: room.participants.size,
       },
@@ -279,7 +319,7 @@ export class RoomManager {
 
     logger.info(
       {
-        roomId: id,
+        roomId,
         votesRevealed: revealed.length,
         unanimousValue: unanimousValue || "none",
       },
@@ -287,7 +327,7 @@ export class RoomManager {
     );
 
     namespace
-      .to(id)
+      .to(roomId)
       .emit("reveal:complete", { revealedVotes: revealed, unanimousValue });
   }
 
@@ -295,10 +335,11 @@ export class RoomManager {
     roomId: string,
     userId: string,
   ): false | { roomDeleted: boolean; wasInRoom: boolean } {
-    const room = this.rooms.get(roomId);
+    const normalizedId = this.normalizeRoomId(roomId);
+    const room = this.rooms.get(normalizedId);
     if (!room) {
       logger.warn(
-        { roomId, userId },
+        { roomId: normalizedId, userId },
         "Leave room was rejected, room not found",
       );
       return false;
@@ -311,7 +352,7 @@ export class RoomManager {
     if (wasInRoom) {
       logger.info(
         {
-          roomId,
+          roomId: normalizedId,
           userId,
           userName: participant?.name || "unknown",
         },
@@ -320,13 +361,14 @@ export class RoomManager {
     }
 
     if (room.participants.size === 0) {
-      this.rooms.delete(roomId);
-      logger.info({ roomId }, "Room was deleted");
+      this.rooms.delete(normalizedId);
+      this.archivedRooms.add(normalizedId);
+      logger.info({ roomId: normalizedId }, "Room was deleted");
       return { roomDeleted: true, wasInRoom };
     }
 
     logger.info(
-      { roomId, participants: room.participants.size },
+      { roomId: normalizedId, participants: room.participants.size },
       "Room participant count was updated",
     );
     return { roomDeleted: false, wasInRoom };
@@ -354,6 +396,7 @@ export class RoomManager {
 
         if (room.participants.size === 0) {
           this.rooms.delete(roomId);
+          this.archivedRooms.add(roomId);
           logger.info({ roomId }, "Room was deleted");
         } else {
           roomsToUpdate.push(roomId);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -24,8 +24,8 @@ export interface ServerToClientEvents {
 
 export interface ClientToServerEvents {
   "room:create": (
-    data: { name: string },
-    cb: (resp: { roomId: string }) => void,
+    data: { roomName: string },
+    cb: (resp: { roomId: string } | { error: string }) => void,
   ) => void;
   "room:join": (
     data: { roomId: string },


### PR DESCRIPTION
## Summary
- allow users to choose validated room names and surface conflicts from the socket API
- persist archived room identifiers so closed rooms can be reopened by the next creator
- update the home and room flows to sanitize room ids, handle reopen prompts, and broadcast with normalized ids

## Testing
- pnpm --filter server build
- pnpm --filter frontend build

------
https://chatgpt.com/codex/tasks/task_e_68dbdae7dd10832980893bd408052b47